### PR TITLE
"Try 'kiex install <version>'", rather than "Try 'elixir install <versio...

### DIFF
--- a/kiex
+++ b/kiex
@@ -286,7 +286,7 @@ function list_elixirs() {
   if (( ${#elixirs[@]} == 0 ))
   then
     printf "%b" "
-# No kiex elixirs installed yet. Try 'elixir install <version>'.
+# No kiex elixirs installed yet. Try 'kiex install <version>'.
 "
   else
     if [[ -z "${default_elixir}" ]]


### PR DESCRIPTION
...n>'."

The prompt to install an Elixir that is shown immediately after installing Kiex instructs the user to 'elixir install', rather than 'kiex install'.

This is "only" an informative change. No functional changes were made.
