### PR TITLE
Fix broken `list branches` functionality

### DIFF
--- a/kiex
+++ b/kiex
@@ -380,12 +380,7 @@ function kiex_implode() {
 
 function get_elixir_branches() {
   # TODO: add cache support
-  # x=$(curl -i -H "User-Agent: $USER_AGENT" -H "Accept: application/json" -qs https://api.github.com/repos/elixir-lang/elixir/branches |grep '"name":|ETag:')
-  x=$(curl -i -H "User-Agent: $USER_AGENT" -H "Accept: application/json" -qs https://api.github.com/repos/elixir-lang/elixir/branches |grep '"name":')
-  x=${x//\"name\":/}
-  x=${x//[\",]/}
-  x=${x//v/}
-
+  x=$(curl -i -H "User-Agent: $USER_AGENT" -H "Accept: application/json" -qs https://api.github.com/repos/elixir-lang/elixir/branches | grep "name" | python -mjson.tool | grep "name" | sed -E 's/        "name": "(.*)"/\1/')
   echo "$x"
 }
 


### PR DESCRIPTION
So the JSON result for fetching the branches is pretty complex. I tried a couple different ways of slicing and dicing it, but my bash-fu isn't strong enough. So instead I deferred to the usage of `python -mtool.json`. This should be included in any of the supported distributions, but I can certainly understand if you don't want a dependency on that being available. That said, it sure makes this a lot more painless, and now it works too, so there's that.

Anyways, I'm going to be using this, so figured I'd send this change your way.
