### PR TITLE
New GitHub raw urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Prereqs: bash, curl, git
 Run the following to get up and running:
 
 ```
-curl -qs https://raw.github.com/taylor/kiex/master/install | bash -s
+curl -qs https://raw.githubusercontent.com/taylor/kiex/master/install | bash -s
 ```
 
 which will install in $HOME/.kiex.
@@ -86,7 +86,7 @@ How is it like RVM?
  * Sane defaults
  * Uses Unix PATH to manage binary to use
 
-How is it not like RVM? 
+How is it not like RVM?
  * No function over-loading
  * Does not manage/install extra software and prereqs
 
@@ -164,7 +164,7 @@ A update to OTP crypto https://github.com/RoadRunnr/otp/commit/8837c1be2ba8a3c12
    - how to tie to elixir used? gemset like?
    - use dynamo tags?
  * Look at elixir-build for ideas, collaboration
- 
+
 ### License
 
 See [LICENSE file](LICENSE)

--- a/install
+++ b/install
@@ -53,7 +53,7 @@ elif [ "$1" = "update" -a -f "$KIEX_HOME/bin/kiex" ] ; then
 fi
 
 mkdir -p "$KIEX_HOME/"{bin,builds,elixirs,scripts}
-curl -qs -o "$KIEX_HOME/bin/kiex" https://raw.github.com/taylor/kiex/master/kiex
+curl -qs -o "$KIEX_HOME/bin/kiex" https://raw.githubusercontent.com/taylor/kiex/master/kiex
 chmod +x "$KIEX_HOME/bin/kiex"
 #echo "$KIEX_HOME/bin/kiex" setup
 if [ $UPDATE = 1 ] ; then
@@ -73,9 +73,9 @@ fi
 # [[ -f $KIEX_HOME/elixirs/.default ]] && source $KIEX_HOME/elixirs/.default
 # EOF
 # }
-# 
+#
 # create_kiex_env_script
-# 
+#
 #echo "kiex has been installed in $KIEX_HOME"
 #echo "Add the following to your shell's config file (.bashrc/.zshrc):"
 #echo "    [[ -s \"\$HOME/.kiex/scripts/kiex\" ]] && source \"\$HOME/.kiex/scripts/kiex\""


### PR DESCRIPTION
Curl is not following redirects by default and GitHub has new raw urls - https://developer.github.com/changes/2014-04-25-user-content-security/.
