### PR TITLE
fix release path

### DIFF
--- a/kiex
+++ b/kiex
@@ -123,7 +123,7 @@ function readlink_f() {
 
 function check_erlang_release() {
   if [ "$SYSTEM" = "Linux" ] ; then
-    erlang_release_file="$(dirname $(readlink -f $(which erl 2> /dev/null)))/../releases/RELEASES"
+    erlang_release_file="$(dirname $(readlink -f $(which erl 2> /dev/null)))/../../releases/RELEASES"
   elif [ "$SYSTEM" = "Darwin" -o "$SYSTEM" = "FreeBSD" ] ; then
     erlang_release_file="$(dirname $(readlink_f $(which erl 2> /dev/null)))/../releases/RELEASES"
   else


### PR DESCRIPTION
As discussed in https://github.com/taylor/kiex/issues/30 there is a path problem with Erlang releases in the kiex script. I'm still not sure what's the reason for this but at least on (K)Ubuntu 15.04 and Fedora 22 this change is necessary to use the script. 