### PR TITLE
Fix `Failed to use` message

### DIFF
--- a/kiex
+++ b/kiex
@@ -279,7 +279,7 @@ function kiex() {
     #eval "$($HOME/.kiex/bin/kiex $*|grep source)"
     source_line="$(USERSHELL=notcsh $HOME/.kiex/bin/kiex $*|grep source)"
     if [ -z "$source_line" ] ; then
-      echo "Failed to use $*"
+      echo "Failed to $*"
     else
       eval "$source_line"
       shift


### PR DESCRIPTION
For now, if I use a wrong elixir version, it will show message like this:

```
$ kiex use 1.3.0 --default
Failed to use use 1.3.0 --default
```

Since `use` is already in `$*`, no need to put it in the message twice.