### PR TITLE
Add an authetication header for Github requests

### DIFF
--- a/kiex
+++ b/kiex
@@ -18,6 +18,11 @@ USER_AGENT="kiex-elixir-installer"
 
 SYSTEM=$(uname -s)
 
+AUTH_HEADER=()
+if [ -n "$KIEX_OAUTH_TOKEN" ]; then
+    AUTH_HEADER=(-H "Authorization: token ${KIEX_OAUTH_TOKEN}")
+fi
+
 # Running bash -l from csh does not change $SHELL
 if [ -z "$USERSHELL" ] ; then
   USERSHELL=$(basename $SHELL)
@@ -67,7 +72,7 @@ if [ "$INSTALL_KIEX" = 1 ] ; then
     exec "$KIEX_HOME/bin/kiex" selfupdate
   else
     mkdir -p "${KIEX_HOME}/bin"
-    \curl -sSL -o "$KIEX_HOME/bin/kiex" https://raw.githubusercontent.com/taylor/kiex/master/kiex
+    \curl -sSL ${AUTH_HEADER[*]} -o "$KIEX_HOME/bin/kiex" https://raw.githubusercontent.com/taylor/kiex/master/kiex
     chmod +x "$KIEX_HOME/bin/kiex"
 
     echo "Running initial environment setup"
@@ -405,7 +410,7 @@ function self_update() {
   cp kiex kiex.bak-$D
 
   mkdir -p "$KIEX_HOME/bin"
-  \curl -L -H "User-Agent: $USER_AGENT" -sSL -o "$KIEX_HOME/bin/kiex" "$kiex_url"
+  \curl -L ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -sSL -o "$KIEX_HOME/bin/kiex" "$kiex_url"
   chmod +x "$KIEX_HOME/bin/kiex"
   #exec $KIEX_HOME/bin/kiex setup update
   exec $KIEX_HOME/bin/kiex selfupdatereloaded
@@ -440,7 +445,7 @@ function kiex_implode() {
 function get_elixir_branches() {
   # TODO: add cache support
   # x=$(curl -i -H "User-Agent: $USER_AGENT" -H "Accept: application/json" -qs https://api.github.com/repos/elixir-lang/elixir/branches |grep '"name":|ETag:')
-  x=$(\curl -i -H "User-Agent: $USER_AGENT" -H "Accept: application/json" -qs https://api.github.com/repos/elixir-lang/elixir/branches |grep '"name":')
+  x=$(\curl -i ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -H "Accept: application/json" -qs https://api.github.com/repos/elixir-lang/elixir/branches |grep '"name":')
   x=$(echo $x | tr ',' '\n' |grep name\":|sed 's/.*name":"\([^"]*\)"/\1/')
   #x=${x//\"name\":/}
   #x=${x//[\",]/}
@@ -486,7 +491,7 @@ function get_known_elixir_releases() {
 #   xetag=$(echo $x|grep ETag)
 #   x=$(echo $x|grep -v ETag)
 
-  x=$(\curl -i -H "User-Agent: $USER_AGENT" -H 'Accept: application/json' -qs https://api.github.com/repos/elixir-lang/elixir/releases | tr ',' '\n' | grep '"tag_name":')
+  x=$(\curl -i ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -H 'Accept: application/json' -qs https://api.github.com/repos/elixir-lang/elixir/releases | tr ',' '\n' | grep '"tag_name":')
   x=${x//\"tag_name\":/}
   x=${x//[\",]/}
   x=${x//v/}


### PR DESCRIPTION
#23 was merged but then reverted. This is an attempt to get the same effect.

On Travis recently, I had many test failures where [Kiex said](https://travis-ci.org/WhoopInc/dogstatsde/jobs/130827700)

```
+kiex install 1.2.0
Unknown Elixir '1.2.0' ☹ 
```

I'm now running with a version of Kiex that I patched to send an OAuth token to Github and things seem better. Therefore, I think this is still a useful addition.