### PR TITLE
.elixir-version support

### DIFF
--- a/kiex
+++ b/kiex
@@ -884,6 +884,36 @@ function validate_install() {
   fi
 }
 
+function find_local_version_file() {
+  local root="$1"
+  while ! [[ "$root" =~ ^//[^/]*$ ]]; do
+    if [ -e "${root}/.elixir-version" ]; then
+      echo "${root}/.elixir-version"
+      return 0
+    fi
+    [ -n "$root" ] || break
+    root="${root%/*}"
+  done
+  return 1
+}
+
+function determine_elixir_version_file() {
+  PWD=$(pwd)
+  find_local_version_file "$base_path" || {
+    [ "$base_path" != "$PWD" ] && find_local_version_file "$PWD"
+  } || echo "${base_path}/version"
+}
+
+function determine_elixir_version() {
+  local file=$(determine_elixir_version_file)
+  if [ -f "$file" ]; then
+    local version=$(head -1 $file)
+  else
+    local version=""
+  fi
+  echo "$version"
+}
+
 #################################
 #################################
 
@@ -921,22 +951,34 @@ case $action in
     fi
     ;;
   install)
-    [[ -z "$1" ]] && usage && exit 1
-    if [ "$1" = "kiex" ] ; then
+    if [ -z ${1+x} ]; then
+      e_version=$(determine_elixir_version)
+    else
+      e_version=$1
+    fi
+
+    [[ -z "$e_version" ]] && usage && exit 1
+    if [ "$e_version" = "kiex" ] ; then
       setup
       echo "kiex has been installed in $KIEX_HOME"
       echo "Add the following to your shell's config file (.bash_profile/.profile):"
       echo "    [[ -s \"\$HOME/.kiex/scripts/kiex\" ]] && source \"\$HOME/.kiex/scripts/kiex\""
       exit
     fi
-    install_elixir "$1"
+    install_elixir "$e_version"
     ;;
   use)
-    [[ -z "$1" ]] && usage && exit 1
-    if [ "$2" = "--default" -o "$2" = "-default" ] ; then
-      set_default_elixir "$1"
+    if [ -z ${1+x} ] ; then
+      e_version=$(determine_elixir_version)
+    else
+      e_version=$1
     fi
-    use_elixir "$1"
+
+    [[ -z "$e_version" ]] && usage && exit 1
+    if [ "$2" = "--default" -o "$2" = "-default" ] ; then
+      set_default_elixir "$e_version"
+    fi
+    use_elixir "$e_version"
     ;;
   default)
     [[ -z "$1" ]] && usage && exit 1


### PR DESCRIPTION
# Support for `.elixir-version` file

This is the first approach to support `.elixir-version` files. [It's inspired by `rbenv` for rubylang.](https://github.com/rbenv/rbenv#choosing-the-ruby-version)

## Commands
* `kiex install` (without any version given)
* `kiex use` (without any version given)

## What it does

1. The first `.elixir-version` file found by searching the directory of the script you are executing and each of its parent directories until reaching the root of your filesystem.

2. The first `.elixir-version` file found by searching the current working directory and each of its parent directories until reaching the root of your filesystem.

3. A global `~/.kiex/version` file.

If none of these files are present it tells you to pass a version number along with the command.