### PR TITLE
fix Gentoo detection

### DIFF
--- a/kiex
+++ b/kiex
@@ -45,7 +45,7 @@ if [ "$SYSTEM" = "Linux" ] ; then
     DISTRO="Ubuntu"
   elif (( "$(grep -ic Centos /etc/issue)" > 0 )) ; then
     DISTRO="Centos"
-  elif (( "$([[ -f /etc/inittab ]] && grep -ic Gentoo /etc/inittab)" > 0 )) ; then
+  elif [[ -f /etc/gentoo-release ]] ; then
     DISTRO="Gentoo"
   else
     echo "Unknown Linux distribution"


### PR DESCRIPTION
I got
```
bash: line 48: ((: > 0 : syntax error: operand expected (error token is "> 0 ")
```

Simplified the check, I believe the others could be simplified as well (grep exit status should be 0 iff something was found).