### PR TITLE
Adds explicit erlang dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage is based *lightly* on [RVM](http://rvm.io), [kerl](https://github.com/spaw
 
 ### Install
 
-Prereqs: bash, curl, git
+**Prerequisites:** bash, curl, git, erl (a recent, stable erlang installation)
 
 Run the following to get up and running:
 
@@ -34,7 +34,7 @@ List known releases
 List current branches
  * ``` kiex list branches ```
 
-Install a known release or branch
+Install a known release or branch.
  * ``` kiex install 0.12.5 ```
 
 Use specific elixir version


### PR DESCRIPTION
It's possible that multiple people are having [trouble installing elixir](https://github.com/taylor/kiex/issues/41#issuecomment-220889723) because we don't know we need erlang until further down the README. It's also not explicitly stated that it's needed to be installed before anything else.