### PR TITLE
Allow easy installation of latest version

### DIFF
--- a/kiex
+++ b/kiex
@@ -503,6 +503,20 @@ function get_known_elixir_releases() {
   echo "$x" | sed 's/^/    /' | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n
 }
 
+function get_latest_elixir_release() {
+  # TODO: finish adding caching support with etags
+  # xetag=$(curl -i -H "User-Agent: $USER_AGENT" -qs https://api.github.com/repos/elixir-lang/elixir/releases |grep "^ETag")
+  # etag=${xetag//Etag: "/}
+#
+#   x=$(curl -i -H "User-Agent: $USER_AGENT" -H "Accept: application/json" -qs https://api.github.com/repos/elixir-lang/elixir/releases |grep '"tag_name":|ETag')
+#   xetag=$(echo $x|grep ETag)
+#   x=$(echo $x|grep -v ETag)
+
+  x=$(curl -i ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -H 'Accept: application/json' -qs https://api.github.com/repos/elixir-lang/elixir/releases/latest | tr ',' '\n' | grep '"tag_name":' | sed -E 's/"tag_name":"v(.+)"$/\1/')
+  # update_release_cache "$x"
+  echo "$x"
+}
+
 function list_known() {
   echo "Getting the available releases from https://github.com/elixir-lang/elixir/releases"
   echo
@@ -511,6 +525,22 @@ function list_known() {
 
   echo "Known Elixir releases: "
   printf "%b" "${elixir_releases}\n"
+}
+
+function get_latest() {
+  echo "Getting the latest release from https://github.com/elixir-lang/elixir/releases/latest"
+  # add empty line
+  echo
+  local latest_release=$(get_latest_elixir_release)
+  echo "Latest release is ${latest_release}"
+  # add empty line
+  echo
+  read -p "Do you want to install it? [y/n]" -n 1 -r
+
+  if [[ $REPLY =~ ^[Yy]$ ]]
+  then
+    install_elixir $latest_release
+  fi
 }
 
 function valid_known_release() {
@@ -1028,6 +1058,10 @@ case $action in
       echo "kiex has been installed in $KIEX_HOME"
       echo "Add the following to your shell's config file (.bash_profile/.profile):"
       echo "    [[ -s \"\$HOME/.kiex/scripts/kiex\" ]] && source \"\$HOME/.kiex/scripts/kiex\""
+      exit
+    fi
+    if [ "$1" = "latest" ] ; then
+      get_latest
       exit
     fi
     install_elixir "$1"

--- a/kiex
+++ b/kiex
@@ -504,16 +504,8 @@ function get_known_elixir_releases() {
 }
 
 function get_latest_elixir_release() {
-  # TODO: finish adding caching support with etags
-  # xetag=$(curl -i -H "User-Agent: $USER_AGENT" -qs https://api.github.com/repos/elixir-lang/elixir/releases |grep "^ETag")
-  # etag=${xetag//Etag: "/}
-#
-#   x=$(curl -i -H "User-Agent: $USER_AGENT" -H "Accept: application/json" -qs https://api.github.com/repos/elixir-lang/elixir/releases |grep '"tag_name":|ETag')
-#   xetag=$(echo $x|grep ETag)
-#   x=$(echo $x|grep -v ETag)
-
   x=$(curl -i ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -H 'Accept: application/json' -qs https://api.github.com/repos/elixir-lang/elixir/releases/latest | tr ',' '\n' | grep '"tag_name":' | sed -E 's/"tag_name":"v(.+)"$/\1/')
-  # update_release_cache "$x"
+  
   echo "$x"
 }
 


### PR DESCRIPTION
Instead of first listing all versions and choosing the latest one manually, passing 'latest' as an argument to install will do this automatically.