### PR TITLE
[bigfix] wrong setenv for cshell

### DIFF
--- a/kiex
+++ b/kiex
@@ -739,7 +739,7 @@ EOF
 cat <<EOF> $new_file
 setenv ELIXIR_VERSION "$new_ver"
 setenv PATH "${elixirs_source_path}/elixir-${new_ver}/bin:\$PATH"
-setenv MIX_ARCHIVES="${mix_archives_source_path}/elixir-${new_ver}"
+setenv MIX_ARCHIVES "${mix_archives_source_path}/elixir-${new_ver}"
 EOF
 
 ## Fish


### PR DESCRIPTION
Setenv for CSH have format "setenv VARNAME VARVALUE" instead of "setenv VARNAME=VARVALUE"