### PR TITLE
Add comment line filtering code to kiex

### DIFF
--- a/kiex
+++ b/kiex
@@ -151,7 +151,7 @@ function check_erlang_release() {
     return 1
   fi
 
-  erlang_release=($(awk -F, 'NR==1 {gsub(/"/,"",$3);print $3}' "$erlang_release_file" | sed 's/R\([0-9]*\)\([A-Z]\)/\1 \2 /'))
+  erlang_release=($(grep -v '^%' "$erlang_release_file" | awk -F, 'NR==1 {gsub(/"/,"",$3);print $3}' | sed 's/R\([0-9]*\)\([A-Z]\)/\1 \2 /'))
   r="${erlang_release[0]}"
   c="${erlang_release[1]}"
   cn="${erlang_release[2]}"


### PR DESCRIPTION
* Erlang/OTP 20.1 now includes the following comment line
  at the top of the RELEASES file:

  %% coding: utf-8

  This patch adds a grep command to filter out the comment line
  to pick up the correct release string for $erlang_release.