### PR TITLE
Update link to kerl

### DIFF
--- a/kiex
+++ b/kiex
@@ -223,7 +223,7 @@ function erlang_req_info() {
   echo "Erlang installation choices:"
   echo "   * Download - https://www.erlang-solutions.com/downloads/download-erlang-otp"
   echo "                http://www.erlang.org/download.html"
-  echo "   * Kerl - https://github.com/spawngrid/kerl"
+  echo "   * Kerl - https://github.com/kerl/kerl"
   echo "   * Package manager -"
   echo "           Arch: See AUR package,"
   echo "           FreeBSD: pkg install erlang"


### PR DESCRIPTION
spawngrid/kerl redirects to kerl/kerl now. Suggest that repo instead as it the one maintained.