### PR TITLE
Format of RELEASES file changed in OTP 20.1

### DIFF
--- a/kiex
+++ b/kiex
@@ -152,6 +152,10 @@ function check_erlang_release() {
   fi
 
   erlang_release=($(awk -F, 'NR==1 {gsub(/"/,"",$3);print $3}' "$erlang_release_file" | sed 's/R\([0-9]*\)\([A-Z]\)/\1 \2 /'))
+  if [ -z "$erlang_release" ] ; then
+    ## Starting in OTP 20.1, this file has a header comment of %% coding: utf-8 which breaks the above query. NR==2 fixes it.
+    erlang_release=($(awk -F, 'NR==2 {gsub(/"/,"",$3);print $3}' "$erlang_release_file" | sed 's/R\([0-9]*\)\([A-Z]\)/\1 \2 /'))
+  fi
   r="${erlang_release[0]}"
   c="${erlang_release[1]}"
   cn="${erlang_release[2]}"


### PR DESCRIPTION
as of OTP 20.1, the RELEASES file starts with a line like this: `%% coding: utf-8`.

This had kiex telling me that it `Failed to extract the erlang release!`. This isn't the cleanest solution. but I was able to build elixir with OTPs `20.0.5` and `20.1`.

20.1:
```
%% coding: utf-8
[{release,"Erlang/OTP","20","9.1",
          [{kernel,"5.4","/Users/joe/.kerl/installs/20.1/lib/kernel-5.4"},
           {stdlib,"3.4.2","/Users/joe/.kerl/installs/20.1/lib/stdlib-3.4.2"},
           {sasl,"3.1","/Users/joe/.kerl/installs/20.1/lib/sasl-3.1"}],
          permanent}].
```

20.0.5:
```
[{release,"Erlang/OTP","20","9.0.5",
          [{kernel,"5.3.1","/Users/joe/.kerl/installs/20.0.5/lib/kernel-5.3.1"},
           {stdlib,"3.4.1","/Users/joe/.kerl/installs/20.0.5/lib/stdlib-3.4.1"},
           {sasl,"3.0.4","/Users/joe/.kerl/installs/20.0.5/lib/sasl-3.0.4"}],
          permanent}].
```