### PR TITLE
add quotes around curl url for known releases

### DIFF
--- a/kiex
+++ b/kiex
@@ -494,7 +494,7 @@ function get_known_elixir_releases() {
 #   xetag=$(echo $x|grep ETag)
 #   x=$(echo $x|grep -v ETag)
 
-  x=$(\curl -i ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -H 'Accept: application/json' -qs https://api.github.com/repos/elixir-lang/elixir/releases?per_page=100 | tr ',' '\n' | grep '"tag_name":')
+  x=$(\curl -i ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -H 'Accept: application/json' -qs "https://api.github.com/repos/elixir-lang/elixir/releases?per_page=100" | tr ',' '\n' | grep '"tag_name":')
   x=${x//\"tag_name\":/}
   x=${x//[\",]/}
   x=${x//v/}


### PR DESCRIPTION
I ran `kiex implode` then reinstalled kiex, and my `kiex list known` stopped working for some reason. Upon fiddling with the curl command on my command line I discovered this fix:

I get this output when I run the curl manually:
```
\curl -i ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -H 'Accept: application/json' -qs https://api.github.com/repos/elixir-lang/elixir/releases?per_page=100 | tr ',' '\n' | grep '"tag_name":'
zsh: no matches found: https://api.github.com/repos/elixir-lang/elixir/releases?per_page=100
```
But when I add quotes around the github url...
```
\curl -i ${AUTH_HEADER[*]} -H "User-Agent: $USER_AGENT" -H 'Accept: application/json' -qs "https://api.github.com/repos/elixir-lang/elixir/releases?per_page=100" | tr ',' '\n' | grep '"tag_name":'
"tag_name":"v1.7.3"
"tag_name":"v1.7.2"
...
```