### PR TITLE
Preserve known Elixir release order

### DIFF
--- a/kiex
+++ b/kiex
@@ -503,7 +503,7 @@ function get_known_elixir_releases() {
   x=${x//v/}
 
   # update_release_cache "$x"
-  echo "$x" | sed 's/^/    /' | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n
+  echo "$x" | sed 's/^/    /' | tac
 }
 
 function get_latest_elixir_release() {


### PR DESCRIPTION
This prevents preleases (x.x.0-rc.x) being listed after x.x.0 releases.