### PR TITLE
Parameterize Elixir installations using OTP release

### DIFF
--- a/kiex
+++ b/kiex
@@ -590,7 +590,7 @@ function install_elixir() {
   exit_on_invalid_version "$1"
   exit_on_unmet_prereqs
 
-  erl_release=$(erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell | grep -oP '\d+(\.\d+)*')
+  erl_release=$(erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell | grep -oE '\d+(\.\d+)*')
 
   suffix="${version}-${erl_release}"
 

--- a/kiex
+++ b/kiex
@@ -590,7 +590,11 @@ function install_elixir() {
   exit_on_invalid_version "$1"
   exit_on_unmet_prereqs
 
-  install_path="${elixirs_path}/elixir-${version}"
+  erl_release=$(erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell | grep -oP '\d+(\.\d+)*')
+
+  suffix="${version}-${erl_release}"
+
+  install_path="${elixirs_path}/elixir-${suffix}"
 
   cd "$build_path"
   echo "Downloading elixir version ${version}"
@@ -627,25 +631,25 @@ function install_elixir() {
   fi
 
   # For MIX_ARCHIVES - http://elixir-lang.org/docs/master/mix/Mix.Tasks.Archive.html
-  mkdir -p "${mix_archives_path}/elixir-${version}"
+  mkdir -p "${mix_archives_path}/elixir-${suffix}"
 
   echo "Installed Elixir version $version"
-  create_env_file "$version"
+  create_env_file "$suffix"
 
   echo "Load with:"
-  echo "           kiex use ${version} "
+  echo "           kiex use ${suffix} "
   echo "or load the elixir environment file with: "
   printf "%b" "   "
 
   case $(basename $SHELL) in
     fish)
-      printf "%b" "source ${elixirs_source_path}/.elixir-${version}.env.fish\n"
+      printf "%b" "source ${elixirs_source_path}/.elixir-${suffix}.env.fish\n"
       ;;
     csh|tcsh)
-      printf "%b" "source ${elixirs_source_path}/.elixir-${version}.env.csh\n"
+      printf "%b" "source ${elixirs_source_path}/.elixir-${suffix}.env.csh\n"
       ;;
     *)
-      printf "%b" "source ${elixirs_source_path}/elixir-${version}.env\n"
+      printf "%b" "source ${elixirs_source_path}/elixir-${suffix}.env\n"
       ;;
   esac
 }


### PR DESCRIPTION
Elixir builds and therefore installations are specific to the Erlang/OTP release used. E.g. building the same Elixir 1.16.3 version on the 25 release of Erlang/OTP will not work on 26 release.

This small addition ensures the build is parameterized by both the Elixir version requested and the Erlang/OTP release used to build it.

For example you may have global Erlang/OTP 26 while project specific may be version 25. Installing Elixir globally or inside the project will then result in two Elixirs installed:

```
$ kiex list

kiex elixirs

   elixir-1.16.3-25
=> elixir-1.16.3-26
```

Then in your project you may:
`source "$HOME/.kiex/elixirs/elixir-1.16.3-25.env"`

While globally in your $HOME/.bashrc:
`source "$HOME/.kiex/elixirs/elixir-1.16.3-26.env"`

This change only touches `install_elixir` function and leaves surrounding code unchanged and unchecked. Someone who knows the kiex source code should check if the right suffix (elixir version + otp release) is used where necessary.
